### PR TITLE
Add (very basic) support for quotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,9 @@ try parser.next(as: Person.self) // => Optional<Person(firstName: "joe", lastNam
 ```swift
 let parser = try CSVParser(url: url)
 let parser = try CSVParser(url: url, delimiter: "|")
-let parser = try CSVParser(url: url, delimiter: "|", hasHeader: true)
-let parser = try CSVParser(url: url, delimiter: "|", header: ["firstName", "lastName", "age"])
+let parser = try CSVParser(url: url, delimiter: "|", quotationMark: "'")
+let parser = try CSVParser(url: url, delimiter: "|", quotationMark: "'", hasHeader: true)
+let parser = try CSVParser(url: url, delimiter: "|", quotationMark: "'", header: ["firstName", "lastName", "age"])
 ```
 
 ## Create parser from `String`
@@ -99,16 +100,18 @@ let string3 = "firstName|lastName|age\njoe|doe|28\njane|doe|21"
 
 let parser = try CSVParser(string: string)
 let parser = try CSVParser(string: string2, delimiter: "|")
-let parser = try CSVParser(string: string3, delimiter: "|", hasHeader: true)
-let parser = try CSVParser(string: string2, delimiter: "|", header: ["firstName", "lastName", "age"])
+let parser = try CSVParser(string: string3, delimiter: "|", quotationMark: "'")
+let parser = try CSVParser(string: string3, delimiter: "|", quotationMark: "'", hasHeader: true)
+let parser = try CSVParser(string: string2, delimiter: "|", quotationMark: "'", header: ["firstName", "lastName", "age"])
 ```
 
 ## Create parser from `Data`
 ```swift
 let parser = try CSVParser(data: data)
 let parser = try CSVParser(data: data, delimiter: "|")
-let parser = try CSVParser(data: data, delimiter: "|", hasHeader: true)
-let parser = try CSVParser(data: data, delimiter: "|", header: ["firstName", "lastName", "age"])
+let parser = try CSVParser(data: data, delimiter: "|", quotationMark: "'")
+let parser = try CSVParser(data: data, delimiter: "|", quotationMark: "'", hasHeader: true)
+let parser = try CSVParser(data: data, delimiter: "|", quotationMark: "'", header: ["firstName", "lastName", "age"])
 ```
 
 # Disclaimer

--- a/Sources/CSV/CSVParser+Convenience.swift
+++ b/Sources/CSV/CSVParser+Convenience.swift
@@ -10,45 +10,57 @@ import Foundation
 extension CSVParser {
     
     // MARK: - Init from URL
-    public convenience init(url: URL, delimiter: Character, hasHeader: Bool = false, header: [String]? = nil) throws {
+    public convenience init(url: URL, delimiter: Character, quotationMark: Character = "\"", hasHeader: Bool = false, header: [String]? = nil) throws {
         guard let delimiter = delimiter.asciiValue else {
             throw CSVParserError.invalidDelimiter
         }
-        
-        try self.init(url: url, delimiter: delimiter, hasHeader: hasHeader, header: header)
+
+        guard let quotationMark = quotationMark.asciiValue else {
+            throw CSVParserError.invalidQuotationMark
+        }
+
+        try self.init(url: url, delimiter: delimiter, quotationMark: quotationMark, hasHeader: hasHeader, header: header)
     }
     
-    public convenience init(url: URL, delimiter: UInt8 = 0x2C, hasHeader: Bool = false, header: [String]? = nil) throws {
+    public convenience init(url: URL, delimiter: UInt8 = 0x2C, quotationMark: UInt8 = 0x22, hasHeader: Bool = false, header: [String]? = nil) throws {
         guard let stream = InputStream(url: url) else {
             throw CSVParserError.invalidURL
         }
         
-        self.init(inputStream: stream, delimiter: delimiter, hasHeader: hasHeader, header: header)
+        self.init(inputStream: stream, delimiter: delimiter, quotationMark: quotationMark, hasHeader: hasHeader, header: header)
     }
     
     // MARK: - Init with Data
-    public convenience init(data: Data, delimiter: Character, hasHeader: Bool = false, header: [String]? = nil) throws {
+    public convenience init(data: Data, delimiter: Character, quotationMark: Character = "\"", hasHeader: Bool = false, header: [String]? = nil) throws {
         guard let delimiter = delimiter.asciiValue else {
             throw CSVParserError.invalidDelimiter
         }
         
-        self.init(data: data, delimiter: delimiter, hasHeader: hasHeader, header: header)
+        guard let quotationMark = quotationMark.asciiValue else {
+            throw CSVParserError.invalidQuotationMark
+        }
+
+        self.init(data: data, delimiter: delimiter, quotationMark: quotationMark, hasHeader: hasHeader, header: header)
     }
     
-    public convenience init(data: Data, delimiter: UInt8 = 0x2C, hasHeader: Bool = false, header: [String]? = nil) {
-        self.init(inputStream: InputStream(data: data), delimiter: delimiter, hasHeader: hasHeader, header: header)
+    public convenience init(data: Data, delimiter: UInt8 = 0x2C, quotationMark: UInt8 = 0x22, hasHeader: Bool = false, header: [String]? = nil) {
+        self.init(inputStream: InputStream(data: data), delimiter: delimiter, quotationMark: quotationMark, hasHeader: hasHeader, header: header)
     }
     
     // MARK: - Init with String
-    public convenience init(string: String, delimiter: Character, hasHeader: Bool = false, header: [String]? = nil) throws {
+    public convenience init(string: String, delimiter: Character, quotationMark: Character = "\"", hasHeader: Bool = false, header: [String]? = nil) throws {
         guard let delimiter = delimiter.asciiValue else {
             throw CSVParserError.invalidDelimiter
         }
         
-        self.init(string: string, delimiter: delimiter, hasHeader: hasHeader, header: header)
+        guard let quotationMark = quotationMark.asciiValue else {
+            throw CSVParserError.invalidQuotationMark
+        }
+        
+        self.init(string: string, delimiter: delimiter, quotationMark: quotationMark, hasHeader: hasHeader, header: header)
     }
     
-    public convenience init(string: String, delimiter: UInt8 = 0x2C, hasHeader: Bool = false, header: [String]? = nil) {
+    public convenience init(string: String, delimiter: UInt8 = 0x2C, quotationMark: UInt8 = 0x22, hasHeader: Bool = false, header: [String]? = nil) {
         let data = string.data(using: .utf8)!
         self.init(
             inputStream: InputStream(data: data), // re: force-unwrap (see https://www.objc.io/blog/2018/02/13/string-to-data-and-back/)

--- a/Sources/CSV/CSVParser.swift
+++ b/Sources/CSV/CSVParser.swift
@@ -21,6 +21,7 @@ public class CSVParser {
      
      - Parameter inputStream: The input stream for CSVParser to use to read data from
      - Parameter delimiter: Delimiter to be used to signify a new column
+     - Parameter quotationMark: Character to be used to signify the start/end of a quotation (which may contain delimiters and linebreaks)
      - Parameter hasHeader: Indicates whether the CSV contains a header
      - Parameter header: Manually set a header (if set, hasHeader will be disregarded)
      */

--- a/Sources/CSV/CSVParser.swift
+++ b/Sources/CSV/CSVParser.swift
@@ -54,8 +54,14 @@ public class CSVParser {
         
         while let char = reader.pop()  {
             if isInQuotation {
-                if char == quotationMark && reader.peek() == delimiter {
-                    isInQuotation = false
+                if char == quotationMark {
+                    if reader.peek() == quotationMark {
+                        // two consecutive quotation characters within a quoted field are considered escaped and only added to the field once
+                        fieldBuffer.append(char)
+                        _ = reader.pop()
+                    } else {
+                        isInQuotation = false
+                    }
                 } else {
                     fieldBuffer.append(char)
                 }

--- a/Sources/CSV/CSVParser.swift
+++ b/Sources/CSV/CSVParser.swift
@@ -54,7 +54,7 @@ public class CSVParser {
         
         while let char = reader.pop()  {
             if isInQuotation {
-                if char == quotationMark {
+                if char == quotationMark && reader.peek() == delimiter {
                     isInQuotation = false
                 } else {
                     fieldBuffer.append(char)
@@ -78,7 +78,7 @@ public class CSVParser {
                     }
 
                     return !rowBuffer.isEmpty ? rowBuffer : nil
-                } else if char == quotationMark {
+                } else if char == quotationMark && fieldBuffer.isEmpty {
                     isInQuotation = true
                 } else {
                     fieldBuffer.append(char)

--- a/Sources/CSV/CSVParserError.swift
+++ b/Sources/CSV/CSVParserError.swift
@@ -17,7 +17,10 @@ public enum CSVParserError: Error {
     
     /// Delimiter Character is not ASCII Encodable
     case invalidDelimiter
-    
+
+    /// Quotation Mark  is not ASCII Encodable
+    case invalidQuotationMark
+
     /// Provided String not UTF-8 Encodabe
     case invalidString
     

--- a/Tests/CSVTests/Resources/BinanceDataEntry.swift
+++ b/Tests/CSVTests/Resources/BinanceDataEntry.swift
@@ -21,4 +21,5 @@ struct BinanceDataEntry: Decodable {
     let takerQuoteAssetVolume: Double
     let ignore: Bool
     let textWithQuotation: String
+    let textThatContainsQuotes: String
 }

--- a/Tests/CSVTests/Resources/BinanceDataEntry.swift
+++ b/Tests/CSVTests/Resources/BinanceDataEntry.swift
@@ -20,4 +20,5 @@ struct BinanceDataEntry: Decodable {
     let takerBaseAssetVolume: Double
     let takerQuoteAssetVolume: Double
     let ignore: Bool
+    let textWithQuotation: String
 }

--- a/Tests/CSVTests/Tests/CSVParserAsyncTests.swift
+++ b/Tests/CSVTests/Tests/CSVParserAsyncTests.swift
@@ -11,28 +11,28 @@ import XCTest
 #if !os(Linux)
 @available(macOS 12.0.0, *)
 final class CSVParserAsyncTests: XCTestCase {
-    let data: Data = "1635724800000,53228.92000000,53265.47000000,53218.59000000,53233.40000000,1.00359000,1635724859999,53430.40481810,64,0.97545000,51931.96981100,0".data(using: .utf8)!
+    let data: Data = "1635724800000,53228.92000000,53265.47000000,53218.59000000,53233.40000000,1.00359000,1635724859999,53430.40481810,64,0.97545000,51931.96981100,0,\"this, that\n& other\"".data(using: .utf8)!
     
     func testAysncCSVParser() async throws {
         let parser = CSVParser(data: data)
         let asyncParser = AsyncCSVParser(parser: parser)
         
         for await item: [String] in asyncParser {
-            XCTAssert(item == ["1635724800000", "53228.92000000", "53265.47000000", "53218.59000000", "53233.40000000", "1.00359000", "1635724859999", "53430.40481810", "64", "0.97545000", "51931.96981100", "0"])
+            XCTAssert(item == ["1635724800000", "53228.92000000", "53265.47000000", "53218.59000000", "53233.40000000", "1.00359000", "1635724859999", "53430.40481810", "64", "0.97545000", "51931.96981100", "0", "this, that\n& other"])
         }
         
         XCTAssert(parser.next() == nil)
     }
     
     func testAsyncDictionaryCSVParser() async throws {
-        let parser = CSVParser(data: data, header: ["openTime", "open", "high", "low", "close", "volume", "closeTime", "quoteAssetVolume", "numberOfTrades", "takerBaseAssetVolume", "takerQuoteAssetVolume", "ignore"])
+        let parser = CSVParser(data: data, header: ["openTime", "open", "high", "low", "close", "volume", "closeTime", "quoteAssetVolume", "numberOfTrades", "takerBaseAssetVolume", "takerQuoteAssetVolume", "ignore", "textWithQuotation"])
         let asyncParser = AsyncDictionaryCSVParser(parser: parser)
         
         for try await item: [String: String] in asyncParser {
             let keys: [String] = Array(item.keys)
             
             XCTAssert(
-                keys.containsSameElements(as: ["openTime", "open", "high", "low", "close", "volume", "closeTime", "quoteAssetVolume", "numberOfTrades", "takerBaseAssetVolume", "takerQuoteAssetVolume", "ignore"])
+                keys.containsSameElements(as: ["openTime", "open", "high", "low", "close", "volume", "closeTime", "quoteAssetVolume", "numberOfTrades", "takerBaseAssetVolume", "takerQuoteAssetVolume", "ignore", "textWithQuotation"])
             )
             
             XCTAssert(item["openTime"] == "1635724800000")
@@ -47,13 +47,14 @@ final class CSVParserAsyncTests: XCTestCase {
             XCTAssert(item["takerBaseAssetVolume"] == "0.97545000")
             XCTAssert(item["takerQuoteAssetVolume"] == "51931.96981100")
             XCTAssert(item["ignore"] == "0")
+            XCTAssert(item["textWithQuotation"] == "this, that\n& other")
         }
         
         XCTAssert(parser.next() == nil)
     }
     
     func testAsyncCodableCSVParser() async throws {
-        let parser = CSVParser(data: data, header: ["openTime", "open", "high", "low", "close", "volume", "closeTime", "quoteAssetVolume", "numberOfTrades", "takerBaseAssetVolume", "takerQuoteAssetVolume", "ignore"])
+        let parser = CSVParser(data: data, header: ["openTime", "open", "high", "low", "close", "volume", "closeTime", "quoteAssetVolume", "numberOfTrades", "takerBaseAssetVolume", "takerQuoteAssetVolume", "ignore", "textWithQuotation"])
         let asyncParser = AsyncCodableCSVParser(parser: parser, as: BinanceDataEntry.self)
         
         for try await item: BinanceDataEntry in asyncParser {
@@ -69,6 +70,7 @@ final class CSVParserAsyncTests: XCTestCase {
             XCTAssert(item.takerBaseAssetVolume == 0.97545)
             XCTAssert(item.takerQuoteAssetVolume == 51931.969811)
             XCTAssert(item.ignore == false)
+            XCTAssert(item.textWithQuotation == "this, that\n& other")
         }
         
         XCTAssert(parser.next() == nil)

--- a/Tests/CSVTests/Tests/CSVParserAsyncTests.swift
+++ b/Tests/CSVTests/Tests/CSVParserAsyncTests.swift
@@ -11,28 +11,28 @@ import XCTest
 #if !os(Linux)
 @available(macOS 12.0.0, *)
 final class CSVParserAsyncTests: XCTestCase {
-    let data: Data = "1635724800000,53228.92000000,53265.47000000,53218.59000000,53233.40000000,1.00359000,1635724859999,53430.40481810,64,0.97545000,51931.96981100,0,\"this, that\n& other\"".data(using: .utf8)!
+    let data: Data = "1635724800000,53228.92000000,53265.47000000,53218.59000000,53233.40000000,1.00359000,1635724859999,53430.40481810,64,0.97545000,51931.96981100,0,\"this, that\n& other\",this is \"great\"".data(using: .utf8)!
     
     func testAysncCSVParser() async throws {
         let parser = CSVParser(data: data)
         let asyncParser = AsyncCSVParser(parser: parser)
         
         for await item: [String] in asyncParser {
-            XCTAssert(item == ["1635724800000", "53228.92000000", "53265.47000000", "53218.59000000", "53233.40000000", "1.00359000", "1635724859999", "53430.40481810", "64", "0.97545000", "51931.96981100", "0", "this, that\n& other"])
+            XCTAssert(item == ["1635724800000", "53228.92000000", "53265.47000000", "53218.59000000", "53233.40000000", "1.00359000", "1635724859999", "53430.40481810", "64", "0.97545000", "51931.96981100", "0", "this, that\n& other", "this is \"great\""])
         }
         
         XCTAssert(parser.next() == nil)
     }
     
     func testAsyncDictionaryCSVParser() async throws {
-        let parser = CSVParser(data: data, header: ["openTime", "open", "high", "low", "close", "volume", "closeTime", "quoteAssetVolume", "numberOfTrades", "takerBaseAssetVolume", "takerQuoteAssetVolume", "ignore", "textWithQuotation"])
+        let parser = CSVParser(data: data, header: ["openTime", "open", "high", "low", "close", "volume", "closeTime", "quoteAssetVolume", "numberOfTrades", "takerBaseAssetVolume", "takerQuoteAssetVolume", "ignore", "textWithQuotation", "textThatContainsQuotes"])
         let asyncParser = AsyncDictionaryCSVParser(parser: parser)
         
         for try await item: [String: String] in asyncParser {
             let keys: [String] = Array(item.keys)
             
             XCTAssert(
-                keys.containsSameElements(as: ["openTime", "open", "high", "low", "close", "volume", "closeTime", "quoteAssetVolume", "numberOfTrades", "takerBaseAssetVolume", "takerQuoteAssetVolume", "ignore", "textWithQuotation"])
+                keys.containsSameElements(as: ["openTime", "open", "high", "low", "close", "volume", "closeTime", "quoteAssetVolume", "numberOfTrades", "takerBaseAssetVolume", "takerQuoteAssetVolume", "ignore", "textWithQuotation", "textThatContainsQuotes"])
             )
             
             XCTAssert(item["openTime"] == "1635724800000")
@@ -48,13 +48,14 @@ final class CSVParserAsyncTests: XCTestCase {
             XCTAssert(item["takerQuoteAssetVolume"] == "51931.96981100")
             XCTAssert(item["ignore"] == "0")
             XCTAssert(item["textWithQuotation"] == "this, that\n& other")
+            XCTAssert(item["textThatContainsQuotes"] == "this is \"great\"")
         }
         
         XCTAssert(parser.next() == nil)
     }
     
     func testAsyncCodableCSVParser() async throws {
-        let parser = CSVParser(data: data, header: ["openTime", "open", "high", "low", "close", "volume", "closeTime", "quoteAssetVolume", "numberOfTrades", "takerBaseAssetVolume", "takerQuoteAssetVolume", "ignore", "textWithQuotation"])
+        let parser = CSVParser(data: data, header: ["openTime", "open", "high", "low", "close", "volume", "closeTime", "quoteAssetVolume", "numberOfTrades", "takerBaseAssetVolume", "takerQuoteAssetVolume", "ignore", "textWithQuotation", "textThatContainsQuotes"])
         let asyncParser = AsyncCodableCSVParser(parser: parser, as: BinanceDataEntry.self)
         
         for try await item: BinanceDataEntry in asyncParser {
@@ -71,6 +72,7 @@ final class CSVParserAsyncTests: XCTestCase {
             XCTAssert(item.takerQuoteAssetVolume == 51931.969811)
             XCTAssert(item.ignore == false)
             XCTAssert(item.textWithQuotation == "this, that\n& other")
+            XCTAssert(item.textThatContainsQuotes == "this is \"great\"")
         }
         
         XCTAssert(parser.next() == nil)

--- a/Tests/CSVTests/Tests/CSVParserTests.swift
+++ b/Tests/CSVTests/Tests/CSVParserTests.swift
@@ -14,7 +14,7 @@ import Foundation
 final class CSVParserTests: QuickSpec {
     
     override func spec() {
-        let str = "1635724800000,53228.92000000,53265.47000000,53218.59000000,53233.40000000,1.00359000,,53430.40481810,64,0.97545000,51931.96981100,0\r\n"
+        let str = "1635724800000,53228.92000000,53265.47000000,53218.59000000,53233.40000000,1.00359000,,53430.40481810,64,0.97545000,51931.96981100,0,\"this, that\n& other\"\r\n"
         let data = str.data(using: .utf8)!
         
         describe("inputStream based parser") {
@@ -27,7 +27,7 @@ final class CSVParserTests: QuickSpec {
                 }
                 
                 it("should have correct values") {
-                    expect(row) ==  ["1635724800000", "53228.92000000", "53265.47000000", "53218.59000000", "53233.40000000", "1.00359000", "", "53430.40481810", "64", "0.97545000", "51931.96981100", "0"]
+                    expect(row) ==  ["1635724800000", "53228.92000000", "53265.47000000", "53218.59000000", "53233.40000000", "1.00359000", "", "53430.40481810", "64", "0.97545000", "51931.96981100", "0", "this, that\n& other"]
                 }
                 
                 let parser2 = CSVParser(string: "1,2,3\n4,5,6\n\n")
@@ -53,7 +53,7 @@ final class CSVParserTests: QuickSpec {
                     expect(row1).to(beNil())
                 }
                 
-                let parser2 = CSVParser(data: data, header: ["openTime", "open", "high", "low", "close", "volume", "closeTime", "quoteAssetVolume", "numberOfTrades", "takerBaseAssetVolume", "takerQuoteAssetVolume", "ignore"])
+                let parser2 = CSVParser(data: data, header: ["openTime", "open", "high", "low", "close", "volume", "closeTime", "quoteAssetVolume", "numberOfTrades", "takerBaseAssetVolume", "takerQuoteAssetVolume", "ignore", "textWithQuotation"])
                 let row2 = try? parser2.nextAsDict()
                 
                 it("should not be nil") {
@@ -63,7 +63,7 @@ final class CSVParserTests: QuickSpec {
                 it("should have correct keys") {
                     let keys: [String] = row2?.keys != nil ? Array(row2!.keys) : []
                     expect(
-                        keys.containsSameElements(as: ["openTime", "open", "high", "low", "close", "volume", "closeTime", "quoteAssetVolume", "numberOfTrades", "takerBaseAssetVolume", "takerQuoteAssetVolume", "ignore"])
+                        keys.containsSameElements(as: ["openTime", "open", "high", "low", "close", "volume", "closeTime", "quoteAssetVolume", "numberOfTrades", "takerBaseAssetVolume", "takerQuoteAssetVolume", "ignore", "textWithQuotation"])
                     ) == true
                 }
                 
@@ -80,6 +80,7 @@ final class CSVParserTests: QuickSpec {
                     expect(row2?["takerBaseAssetVolume"]) == "0.97545000"
                     expect(row2?["takerQuoteAssetVolume"]) == "51931.96981100"
                     expect(row2?["ignore"]) == "0"
+                    expect(row2?["textWithQuotation"]) == "this, that\n& other"
                 }
                 
                 let parser3 = CSVParser(data: "ben,koska\nbill".data(using: .utf8)!, header: ["firstName", "lastName"])
@@ -96,7 +97,7 @@ final class CSVParserTests: QuickSpec {
             }
             
             context("decodable based response") {
-                let parser = CSVParser(data: data, header: ["openTime", "open", "high", "low", "close", "volume", "closeTime", "quoteAssetVolume", "numberOfTrades", "takerBaseAssetVolume", "takerQuoteAssetVolume", "ignore"])
+                let parser = CSVParser(data: data, header: ["openTime", "open", "high", "low", "close", "volume", "closeTime", "quoteAssetVolume", "numberOfTrades", "takerBaseAssetVolume", "takerQuoteAssetVolume", "ignore", "textWithQuotation"])
                 let row = try? parser.next(as: BinanceDataEntry.self)
                 
                 it("should not be nil") {
@@ -116,6 +117,7 @@ final class CSVParserTests: QuickSpec {
                     expect(row?.takerBaseAssetVolume) == 0.97545
                     expect(row?.takerQuoteAssetVolume) == 51931.969811
                     expect(row?.ignore) == false
+                    expect(row?.textWithQuotation).to(equal("this, that\n& other"))
                 }
                 
                 let parser2 = CSVParser(string: "firstName,lastName", hasHeader: true)
@@ -131,13 +133,13 @@ final class CSVParserTests: QuickSpec {
             }
             
             context("parse header") {
-                let dataWithHeader = "openTime,open,high,low,close,volume,closeTime,quoteAssetVolume,numberOfTrades,takerBaseAssetVolume,takerQuoteAssetVolume,ignore\n1635724800000,53228.92000000,53265.47000000,53218.59000000,53233.40000000,1.00359000,,53430.40481810,64,0.97545000,51931.96981100,0".data(using: .utf8)!
+                let dataWithHeader = "openTime,open,high,low,close,volume,closeTime,quoteAssetVolume,numberOfTrades,takerBaseAssetVolume,takerQuoteAssetVolume,ignore,textWithQuotation\n1635724800000,53228.92000000,53265.47000000,53218.59000000,53233.40000000,1.00359000,,53430.40481810,64,0.97545000,51931.96981100,0,\"this, that\n& other\"".data(using: .utf8)!
                 
                 let parser = CSVParser(data: dataWithHeader, hasHeader: true)
                 let row = try? parser.next(as: BinanceDataEntry.self)
                 
                 it("should have header") {
-                    expect(parser.header) == ["openTime","open","high","low","close","volume","closeTime","quoteAssetVolume","numberOfTrades","takerBaseAssetVolume","takerQuoteAssetVolume","ignore"]
+                    expect(parser.header) == ["openTime","open","high","low","close","volume","closeTime","quoteAssetVolume","numberOfTrades","takerBaseAssetVolume","takerQuoteAssetVolume","ignore","textWithQuotation"]
                 }
                 
                 it("should not be nil") {
@@ -146,7 +148,7 @@ final class CSVParserTests: QuickSpec {
             }
             
             context("loadAll") {
-                let parser1 = CSVParser(data: "1635724800000,53228.92000000,53265.47000000,53218.59000000,53233.40000000,1.00359000,,53430.40481810,64,0.97545000,51931.96981100,0\n1635724800000,53228.92000000,53265.47000000,53218.59000000,53233.40000000,1.00359000,,53430.40481810,64,0.97545000,51931.96981100,0".data(using: .utf8)!)
+                let parser1 = CSVParser(data: "1635724800000,53228.92000000,53265.47000000,53218.59000000,53233.40000000,1.00359000,,53430.40481810,64,0.97545000,51931.96981100,0\n1635724800000,53228.92000000,53265.47000000,53218.59000000,53233.40000000,1.00359000,,53430.40481810,64,0.97545000,51931.96981100,0,\"this, that\n& other\"".data(using: .utf8)!)
                 
                 let response1 = parser1.loadAll()
                 
@@ -162,7 +164,7 @@ final class CSVParserTests: QuickSpec {
                 }
                 
                 it("should correct values") {
-                    expect(response1) == [["1635724800000", "53228.92000000", "53265.47000000", "53218.59000000", "53233.40000000", "1.00359000", "", "53430.40481810", "64", "0.97545000", "51931.96981100", "0"], ["1635724800000", "53228.92000000", "53265.47000000", "53218.59000000", "53233.40000000", "1.00359000", "", "53430.40481810", "64", "0.97545000", "51931.96981100", "0"]]
+                    expect(response1) == [["1635724800000", "53228.92000000", "53265.47000000", "53218.59000000", "53233.40000000", "1.00359000", "", "53430.40481810", "64", "0.97545000", "51931.96981100", "0"], ["1635724800000", "53228.92000000", "53265.47000000", "53218.59000000", "53233.40000000", "1.00359000", "", "53430.40481810", "64", "0.97545000", "51931.96981100", "0", "this, that\n& other"]]
                 }
                 
                 it("should also correct values") {

--- a/Tests/CSVTests/Tests/CSVParserTests.swift
+++ b/Tests/CSVTests/Tests/CSVParserTests.swift
@@ -14,7 +14,7 @@ import Foundation
 final class CSVParserTests: QuickSpec {
     
     override func spec() {
-        let str = "1635724800000,53228.92000000,53265.47000000,53218.59000000,53233.40000000,1.00359000,,53430.40481810,64,0.97545000,51931.96981100,0,\"this, that\n& other\"\r\n"
+        let str = "1635724800000,53228.92000000,53265.47000000,53218.59000000,53233.40000000,1.00359000,,53430.40481810,64,0.97545000,51931.96981100,0,\"this, that\n& other\",this is \"great\"\r\n"
         let data = str.data(using: .utf8)!
         
         describe("inputStream based parser") {
@@ -27,7 +27,7 @@ final class CSVParserTests: QuickSpec {
                 }
                 
                 it("should have correct values") {
-                    expect(row) ==  ["1635724800000", "53228.92000000", "53265.47000000", "53218.59000000", "53233.40000000", "1.00359000", "", "53430.40481810", "64", "0.97545000", "51931.96981100", "0", "this, that\n& other"]
+                    expect(row) ==  ["1635724800000", "53228.92000000", "53265.47000000", "53218.59000000", "53233.40000000", "1.00359000", "", "53430.40481810", "64", "0.97545000", "51931.96981100", "0", "this, that\n& other", "this is \"great\""]
                 }
                 
                 let parser2 = CSVParser(string: "1,2,3\n4,5,6\n\n")
@@ -53,7 +53,7 @@ final class CSVParserTests: QuickSpec {
                     expect(row1).to(beNil())
                 }
                 
-                let parser2 = CSVParser(data: data, header: ["openTime", "open", "high", "low", "close", "volume", "closeTime", "quoteAssetVolume", "numberOfTrades", "takerBaseAssetVolume", "takerQuoteAssetVolume", "ignore", "textWithQuotation"])
+                let parser2 = CSVParser(data: data, header: ["openTime", "open", "high", "low", "close", "volume", "closeTime", "quoteAssetVolume", "numberOfTrades", "takerBaseAssetVolume", "takerQuoteAssetVolume", "ignore", "textWithQuotation", "textThatContainsQuotes"])
                 let row2 = try? parser2.nextAsDict()
                 
                 it("should not be nil") {
@@ -63,7 +63,7 @@ final class CSVParserTests: QuickSpec {
                 it("should have correct keys") {
                     let keys: [String] = row2?.keys != nil ? Array(row2!.keys) : []
                     expect(
-                        keys.containsSameElements(as: ["openTime", "open", "high", "low", "close", "volume", "closeTime", "quoteAssetVolume", "numberOfTrades", "takerBaseAssetVolume", "takerQuoteAssetVolume", "ignore", "textWithQuotation"])
+                        keys.containsSameElements(as: ["openTime", "open", "high", "low", "close", "volume", "closeTime", "quoteAssetVolume", "numberOfTrades", "takerBaseAssetVolume", "takerQuoteAssetVolume", "ignore", "textWithQuotation", "textThatContainsQuotes"])
                     ) == true
                 }
                 
@@ -81,6 +81,7 @@ final class CSVParserTests: QuickSpec {
                     expect(row2?["takerQuoteAssetVolume"]) == "51931.96981100"
                     expect(row2?["ignore"]) == "0"
                     expect(row2?["textWithQuotation"]) == "this, that\n& other"
+                    expect(row2?["textThatContainsQuotes"]) == "this is \"great\""
                 }
                 
                 let parser3 = CSVParser(data: "ben,koska\nbill".data(using: .utf8)!, header: ["firstName", "lastName"])
@@ -97,7 +98,7 @@ final class CSVParserTests: QuickSpec {
             }
             
             context("decodable based response") {
-                let parser = CSVParser(data: data, header: ["openTime", "open", "high", "low", "close", "volume", "closeTime", "quoteAssetVolume", "numberOfTrades", "takerBaseAssetVolume", "takerQuoteAssetVolume", "ignore", "textWithQuotation"])
+                let parser = CSVParser(data: data, header: ["openTime", "open", "high", "low", "close", "volume", "closeTime", "quoteAssetVolume", "numberOfTrades", "takerBaseAssetVolume", "takerQuoteAssetVolume", "ignore", "textWithQuotation", "textThatContainsQuotes"])
                 let row = try? parser.next(as: BinanceDataEntry.self)
                 
                 it("should not be nil") {
@@ -118,6 +119,7 @@ final class CSVParserTests: QuickSpec {
                     expect(row?.takerQuoteAssetVolume) == 51931.969811
                     expect(row?.ignore) == false
                     expect(row?.textWithQuotation).to(equal("this, that\n& other"))
+                    expect(row?.textThatContainsQuotes).to(equal("this is \"great\""))
                 }
                 
                 let parser2 = CSVParser(string: "firstName,lastName", hasHeader: true)
@@ -133,13 +135,13 @@ final class CSVParserTests: QuickSpec {
             }
             
             context("parse header") {
-                let dataWithHeader = "openTime,open,high,low,close,volume,closeTime,quoteAssetVolume,numberOfTrades,takerBaseAssetVolume,takerQuoteAssetVolume,ignore,textWithQuotation\n1635724800000,53228.92000000,53265.47000000,53218.59000000,53233.40000000,1.00359000,,53430.40481810,64,0.97545000,51931.96981100,0,\"this, that\n& other\"".data(using: .utf8)!
+                let dataWithHeader = "openTime,open,high,low,close,volume,closeTime,quoteAssetVolume,numberOfTrades,takerBaseAssetVolume,takerQuoteAssetVolume,ignore,textWithQuotation,textThatContainsQuotes\n1635724800000,53228.92000000,53265.47000000,53218.59000000,53233.40000000,1.00359000,,53430.40481810,64,0.97545000,51931.96981100,0,\"this, that\n& other\",this is \"great\"".data(using: .utf8)!
                 
                 let parser = CSVParser(data: dataWithHeader, hasHeader: true)
                 let row = try? parser.next(as: BinanceDataEntry.self)
                 
                 it("should have header") {
-                    expect(parser.header) == ["openTime","open","high","low","close","volume","closeTime","quoteAssetVolume","numberOfTrades","takerBaseAssetVolume","takerQuoteAssetVolume","ignore","textWithQuotation"]
+                    expect(parser.header) == ["openTime","open","high","low","close","volume","closeTime","quoteAssetVolume","numberOfTrades","takerBaseAssetVolume","takerQuoteAssetVolume","ignore","textWithQuotation","textThatContainsQuotes"]
                 }
                 
                 it("should not be nil") {
@@ -148,7 +150,7 @@ final class CSVParserTests: QuickSpec {
             }
             
             context("loadAll") {
-                let parser1 = CSVParser(data: "1635724800000,53228.92000000,53265.47000000,53218.59000000,53233.40000000,1.00359000,,53430.40481810,64,0.97545000,51931.96981100,0\n1635724800000,53228.92000000,53265.47000000,53218.59000000,53233.40000000,1.00359000,,53430.40481810,64,0.97545000,51931.96981100,0,\"this, that\n& other\"".data(using: .utf8)!)
+                let parser1 = CSVParser(data: "1635724800000,53228.92000000,53265.47000000,53218.59000000,53233.40000000,1.00359000,,53430.40481810,64,0.97545000,51931.96981100,0\n1635724800000,53228.92000000,53265.47000000,53218.59000000,53233.40000000,1.00359000,,53430.40481810,64,0.97545000,51931.96981100,0,\"this, that\n& other\",this is \"great\"".data(using: .utf8)!)
                 
                 let response1 = parser1.loadAll()
                 
@@ -164,7 +166,7 @@ final class CSVParserTests: QuickSpec {
                 }
                 
                 it("should correct values") {
-                    expect(response1) == [["1635724800000", "53228.92000000", "53265.47000000", "53218.59000000", "53233.40000000", "1.00359000", "", "53430.40481810", "64", "0.97545000", "51931.96981100", "0"], ["1635724800000", "53228.92000000", "53265.47000000", "53218.59000000", "53233.40000000", "1.00359000", "", "53430.40481810", "64", "0.97545000", "51931.96981100", "0", "this, that\n& other"]]
+                    expect(response1) == [["1635724800000", "53228.92000000", "53265.47000000", "53218.59000000", "53233.40000000", "1.00359000", "", "53430.40481810", "64", "0.97545000", "51931.96981100", "0"], ["1635724800000", "53228.92000000", "53265.47000000", "53218.59000000", "53233.40000000", "1.00359000", "", "53430.40481810", "64", "0.97545000", "51931.96981100", "0", "this, that\n& other", "this is \"great\""]]
                 }
                 
                 it("should also correct values") {

--- a/Tests/CSVTests/Tests/CSVParserTests.swift
+++ b/Tests/CSVTests/Tests/CSVParserTests.swift
@@ -148,7 +148,22 @@ final class CSVParserTests: QuickSpec {
                     expect(row).toNot(beNil())
                 }
             }
-            
+
+            context("parse complex quotation") {
+                let data = "quotation marks \"in the middle\" of a string,\"actual, useful quotation containing delimiter\",\"quotation with \"\"escaped\"\" quotation marks in the middle\",\"\"\"quotation\"\" with escaped quotation marks at the beginning\",\"quotation with escaped quotation marks at the \"\"end\"\"\"".data(using: .utf8)!
+                
+                let parser = CSVParser(data: data)
+                let row = parser.next()
+
+                it("should have correct values") {
+                    expect(row?[0]) == "quotation marks \"in the middle\" of a string"
+                    expect(row?[1]) == "actual, useful quotation containing delimiter"
+                    expect(row?[2]) == "quotation with \"escaped\" quotation marks in the middle"
+                    expect(row?[3]) == "\"quotation\" with escaped quotation marks at the beginning"
+                    expect(row?[4]) == "quotation with escaped quotation marks at the \"end\""
+                }
+            }
+
             context("loadAll") {
                 let parser1 = CSVParser(data: "1635724800000,53228.92000000,53265.47000000,53218.59000000,53233.40000000,1.00359000,,53430.40481810,64,0.97545000,51931.96981100,0\n1635724800000,53228.92000000,53265.47000000,53218.59000000,53233.40000000,1.00359000,,53430.40481810,64,0.97545000,51931.96981100,0,\"this, that\n& other\",this is \"great\"".data(using: .utf8)!)
                 


### PR DESCRIPTION
This patch enables parsing data that contains quoted content (which may contain the delimiter or even newlines in a field). By default, the double quote `"` (0x22) is assumed but a different quotation mark may be specified when initializing the `CSVParser`.

Parsing performance takes a small hit because it's necessary to keep checking if the parser is currently in a quotation.

What's missing:

- ~~Support for escaped quotation marks inside a quotation~~
- Probably some more testing :)